### PR TITLE
Fix FastAPI requirement spec in backend

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,2 @@
-fastapi[standard]>=0.115.0<0.116.0
+fastapi[standard]>=0.115.0,<0.116.0
 rembg


### PR DESCRIPTION
## Summary
- format FastAPI dependency range correctly with comma
- ensure backend requirements file ends with newline

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a4550f238832b9dacace6460dc010